### PR TITLE
update audio-player-v2 html and styles for mobile view

### DIFF
--- a/gui/src/app/module/shared/component/audio-player-v2/audio-player-v2.component.html
+++ b/gui/src/app/module/shared/component/audio-player-v2/audio-player-v2.component.html
@@ -1,18 +1,16 @@
-@if (this.audioStatus?.audioID) {
+@if (audioStatus?.audioID) {
+  @let isPlaying = audioStatus?.state === states.playing;
   <div class="player d-flex px-2">
-    <div class="controls py-2 pr-2 d-flex align-items-center">
-      @if (audioStatus?.state !== states.playing) {
-        <div class="clickable p-1" (click)="play()"><i class="bi-play-circle-fill"></i></div>
-      }
-      @if (audioStatus?.state === states.playing) {
-        <div class="clickable p-1" (click)="pause()"><i class="bi-pause-circle-fill"></i></div>
-      }
+    <div class="control play-pause pr-2 d-flex align-items-center">
+      <button type="button" class="p-1" (click)="isPlaying ? pause() : play()">
+        <i [class]="isPlaying ? 'bi-pause-circle-fill' : 'bi-play-circle-fill'"></i>
+      </button>
     </div>
     <div class="flex-grow-1 p-2">
       <div class="mb-1 d-flex justify-content-between">
         <div>
           @if (audioStatus.audioID && audioStatus.mode !== PlayerMode.Standalone) {
-            <a [routerLink]="['/ep', 'ep-'+audioStatus.audioID]">{{ audioStatus.audioID }}</a>
+            <a [routerLink]="['/ep', 'ep-' + audioStatus.audioID]">{{ audioStatus.audioID }}</a>
           }
           @if (audioStatus.audioID && audioStatus.mode === PlayerMode.Standalone) {
             <span>{{ audioStatus.audioID }}</span>
@@ -24,17 +22,12 @@
             <span class=""> - {{ audioStatus.audioName }}</span>
           }
         </div>
-        <div>
-          @if (!audioStatus.listened) {
-            <a class="clickable" (click)="markAsPlayed()">Mark as played</a>
-          }
-          @if (audioStatus.listened) {
-            <a class="clickable" (click)="markAsUnplayed()">Mark as not played</a>
-          }
+        <div class="d-none d-lg-block">
+          <ng-container *ngTemplateOutlet="markAsPlayedUnplayed"></ng-container>
         </div>
       </div>
       <div>
-        <input style="width: 100%" type="range" [min]="0" [max]="audioStatus.totalTime" [formControl]="playerProgressControl">
+        <input class="w-100" type="range" [min]="0" [max]="audioStatus.totalTime" [formControl]="playerProgressControl" />
       </div>
       <div class="d-flex justify-content-between">
         <div class="d-flex">
@@ -44,32 +37,66 @@
           @if (audioStatus.state !== states.ended) {
             <div>
               @if (audioStatus.audioID && audioStatus.mode !== PlayerMode.Standalone) {
-                <a [routerLink]="['/ep', 'ep-'+audioStatus.audioID]" [fragment]="'sec-'+audioStatus.currentTime.toFixed(0)">{{audioStatus?.currentTime | formatSeconds}}</a>
+                <a [routerLink]="['/ep', 'ep-' + audioStatus.audioID]" [fragment]="'sec-' + audioStatus.currentTime.toFixed(0)">{{
+                  audioStatus?.currentTime | formatSeconds
+                }}</a>
               }
               @if (audioStatus.audioID && audioStatus.mode === PlayerMode.Standalone) {
-                <span>{{audioStatus?.currentTime | formatSeconds}}</span>
+                <span>{{ audioStatus?.currentTime | formatSeconds }}</span>
               }
             </div>
           }
         </div>
-        <div>{{audioStatus?.totalTime | formatSeconds}}</div>
+        <div>{{ audioStatus?.totalTime | formatSeconds }}</div>
       </div>
     </div>
-    @if (audioStatus?.state === states.playing) {
-      <div class="sleep p-2 d-flex align-items-center">
+    @if (isPlaying) {
+      <div class="sleep p-2 d-none d-lg-flex align-items-center">
         <div title="Add 15 minutes to sleep timer" class="clickable p-1" (click)="activeSleepTimer()"><i class="bi-stopwatch"></i></div>
         @if (this.audioStatus.sleepTimerRemainder) {
-          <span class="clickable ml-2" title="click to clear" (click)="deactivateSleepTimer()">{{ this.audioStatus.sleepTimerRemainder | formatSeconds:true }} &times;</span>
+          <span class="clickable ml-2" title="click to clear" (click)="deactivateSleepTimer()"
+            >{{ this.audioStatus.sleepTimerRemainder | formatSeconds: true }} &times;</span
+          >
         }
       </div>
     }
-    <div class="volume p-2 d-flex align-items-center">
+    <div class="control p-2 d-none d-lg-flex align-items-center d-sm-none">
       <i class="bi bi-volume-up mr-1"></i>
-      <input type="range" min="0" max="100" [formControl]="volumeControl">
+      <input type="range" min="0" max="100" [formControl]="volumeControl" />
+    </div>
+    <div ngbDropdown [autoClose]="'outside'" class="control d-flex d-lg-none">
+      <button ngbDropdownToggle class="p-3 align-self-center" type="button">
+        <i class="bi bi-volume-up"></i>
+      </button>
+      <div ngbDropdownMenu class="player-dropdown">
+        <input ngbDropdownItem class="volume-vertical" type="range" min="0" max="100" [formControl]="volumeControl" />
+      </div>
+    </div>
+    <div ngbDropdown [autoClose]="'outside'" class="control d-flex d-lg-none align-items-center">
+      <button ngbDropdownToggle class="p-3"><i class="bi bi-three-dots-vertical"></i></button>
+      <div ngbDropdownMenu class="player-dropdown">
+        <li class="player-dropdown-item">
+          <ng-container *ngTemplateOutlet="markAsPlayedUnplayed"></ng-container>
+        </li>
+        @if (audioStatus.state === states.playing) {
+          <li class="player-dropdown-item"><a class="clickable" (click)="activeSleepTimer()">Add 15 minutes to sleep</a></li>
+        }
+        @if (audioStatus.sleepTimerRemainder) {
+          <li class="player-dropdown-item"><a class="clickable" (click)="deactivateSleepTimer()">Clear sleep timer</a></li>
+        }
+        @if (audioStatus.sleepTimerRemainder) {
+          <li>
+            <hr class="dropdown-divider" />
+          </li>
+          <li class="player-dropdown-item">Sleep timer: {{ this.audioStatus.sleepTimerRemainder | formatSeconds: true }}</li>
+        }
+      </div>
     </div>
     @if (audioStatus.mode !== PlayerMode.Standalone && showCloseControl) {
-      <div class="exit d-flex align-items-center px-3">
-        <div class="clickable p-1 close" (click)="closeAudio()">&times;</div>
+      <div class="exit d-flex align-items-center pr-1 px-lg-3 control">
+        <button type="button" class="p-3 p-lg-1" (click)="closeAudio()" aria-label="Stop audio">
+          <i class="bi-stop-circle-fill"></i>
+        </button>
       </div>
     }
     @if (audioStatus?.state === states.failed) {
@@ -79,7 +106,7 @@
             <span class="bg-danger text-white px-2 mr-2">FAILED! Audio couldn't be loaded.</span>
           }
           @if (bandwidthQuotaUsedPcnt >= 99) {
-            <span class="bg-danger text-white px-2 mr-2">SORRY! Quota reached. Audio will become available again in {{timeTillQuotaRefreshed}}.</span>
+            <span class="bg-danger text-white px-2 mr-2">SORRY! Quota reached. Audio will become available again in {{ timeTillQuotaRefreshed }}.</span>
           }
           <a class="btn btn-sm btn-secondary" (click)="closeAudio()">Close player</a>
         </div>
@@ -87,3 +114,12 @@
     }
   </div>
 }
+
+<ng-template #markAsPlayedUnplayed>
+  @if (!audioStatus.listened) {
+    <a class="clickable" (click)="markAsPlayed()">Mark as played</a>
+  }
+  @if (audioStatus.listened) {
+    <a class="clickable" (click)="markAsUnplayed()">Mark as not played</a>
+  }
+</ng-template>

--- a/gui/src/app/module/shared/component/audio-player-v2/audio-player-v2.component.scss
+++ b/gui/src/app/module/shared/component/audio-player-v2/audio-player-v2.component.scss
@@ -1,13 +1,25 @@
+@use "../../../../../scss/theme.scss" as *;
+
 .player {
   font-size: 0.9rem;
   width: 100%;
 
-  .controls {
-    font-size: 2rem;
+  .control {
+    font-size: 1.5rem;
+
+    button {
+      background: 0;
+      border: 0;
+      color: inherit;
+    }
+
+    .dropdown-menu {
+      min-width: auto;
+    }
   }
 
-  .volume {
-    font-size: 1.5rem;
+  .play-pause {
+    font-size: 2rem;
   }
 
   .error-overlay {
@@ -19,5 +31,37 @@
     background-color: rgba(0, 0, 0, 0.8);
     text-align: center;
     font-size: 1.2rem;
+  }
+
+  .volume-vertical {
+    -webkit-appearance: slider-vertical;
+    appearance: slider-vertical;
+    writing-mode: vertical-lr;
+    direction: rtl;
+    width: 36px;
+    height: 200px;
+  }
+
+  .player-dropdown-item {
+    display: block;
+    width: 100%;
+    padding: 0.25rem 1.5rem;
+    clear: both;
+    font-weight: 400;
+    text-align: inherit;
+    white-space: nowrap;
+    background-color: transparent;
+    border: 0;
+  }
+
+  .control .dropdown-toggle::after {
+    display: none;
+  }
+
+  .player-dropdown {
+    @include themeComponent() {
+      color: theme-get("text-color");
+      background-color: theme-get("fg-body-darker");
+    }
   }
 }

--- a/gui/src/app/module/shared/component/audio-player-v2/audio-player-v2.component.ts
+++ b/gui/src/app/module/shared/component/audio-player-v2/audio-player-v2.component.ts
@@ -1,19 +1,18 @@
-import { Component, EventEmitter, Input, OnDestroy, OnInit } from '@angular/core';
-import {AudioService, PlayerMode, PlayerState, Status} from '../../../core/service/audio/audio.service';
+import { Component, Input, inject, OnInit, DestroyRef } from '@angular/core';
+import { AudioService, PlayerMode, PlayerState, Status } from '../../../core/service/audio/audio.service';
 import { UntypedFormControl } from '@angular/forms';
-import { takeUntil } from 'rxjs/operators';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { QuotaService } from 'src/app/module/core/service/quota/quota.service';
 import { RskQuotas } from 'src/app/lib/api-client/models';
 import { addMonths, intervalToDuration, startOfMonth } from 'date-fns';
 
 @Component({
-    selector: 'app-audio-player-v2',
-    templateUrl: './audio-player-v2.component.html',
-    styleUrls: ['./audio-player-v2.component.scss'],
-    standalone: false
+  selector: 'app-audio-player-v2',
+  templateUrl: './audio-player-v2.component.html',
+  styleUrls: ['./audio-player-v2.component.scss'],
+  standalone: false
 })
-export class AudioPlayerV2Component implements OnInit, OnDestroy {
-
+export class AudioPlayerV2Component implements OnInit {
   @Input()
   showCloseControl: boolean = true;
 
@@ -25,26 +24,30 @@ export class AudioPlayerV2Component implements OnInit, OnDestroy {
 
   playerProgressControl: UntypedFormControl = new UntypedFormControl(0);
 
-  timeTillQuotaRefreshed: string = "unknown";
+  timeTillQuotaRefreshed: string = 'unknown';
   bandwidthQuotaUsedPcnt: number = 0;
 
-  private unsubscribe$: EventEmitter<void> = new EventEmitter<void>();
+  mobileMenuOpen = false;
+  mobileVolumeOpen = false;
 
-  constructor(private audioService: AudioService, private quotaService: QuotaService) {
+  protected readonly PlayerMode = PlayerMode;
+
+  private audioService = inject(AudioService);
+  private quotaService = inject(QuotaService);
+  private destroyRef = inject(DestroyRef);
+
+  ngOnInit(): void {
     const interval = intervalToDuration({
       start: new Date(),
       end: startOfMonth(addMonths(new Date(), 1)),
-    })
-    this.timeTillQuotaRefreshed = (interval.days > 0)  ? `${interval.days} days` : (interval.hours > 0 ? `${interval.hours} hours` : `${interval.minutes} minutes`)
-
-    quotaService.quotas$.pipe(takeUntil(this.unsubscribe$)).subscribe((res: RskQuotas) => {
-      this.bandwidthQuotaUsedPcnt = (1 - (res.bandwidthRemainingMib / res.bandwidthTotalMib)) * 100;
     });
-  }
+    this.timeTillQuotaRefreshed = interval.days > 0 ? `${interval.days} days` : interval.hours > 0 ? `${interval.hours} hours` : `${interval.minutes} minutes`;
 
-  ngOnInit(): void {
+    this.quotaService.quotas$.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((res: RskQuotas) => {
+      this.bandwidthQuotaUsedPcnt = (1 - res.bandwidthRemainingMib / res.bandwidthTotalMib) * 100;
+    });
 
-    this.audioService.status.pipe(takeUntil(this.unsubscribe$)).subscribe((sta: Status) => {
+    this.audioService.status.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((sta: Status) => {
       this.audioStatus = sta;
       if (!sta) {
         return;
@@ -52,24 +55,19 @@ export class AudioPlayerV2Component implements OnInit, OnDestroy {
       this.playerProgressControl.setValue(sta.currentTime, { emitEvent: false });
     });
 
-    // volume is loaded from local storage across sessions
-    this.audioService.volumeLoaded.pipe(takeUntil(this.unsubscribe$)).subscribe((vol) => {
+    // volume is loaded from local storage across session
+    this.audioService.volumeLoaded.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((vol) => {
       this.volumeControl.setValue(vol * 100);
     });
 
     // persist it back if the volume is changed via our control.
-    this.volumeControl.valueChanges.pipe(takeUntil(this.unsubscribe$)).subscribe((v) => {
+    this.volumeControl.valueChanges.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((v) => {
       this.audioService.setVolume(v / 100);
     });
 
-    this.playerProgressControl.valueChanges.pipe(takeUntil(this.unsubscribe$)).subscribe((v) => {
+    this.playerProgressControl.valueChanges.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((v) => {
       this.audioService.seekAudio(v);
     });
-  }
-
-  ngOnDestroy(): void {
-    this.unsubscribe$.next();
-    this.unsubscribe$.complete();
   }
 
   play() {
@@ -95,8 +93,6 @@ export class AudioPlayerV2Component implements OnInit, OnDestroy {
   markAsUnplayed() {
     this.audioService.markAsUnplayed();
   }
-
-  protected readonly PlayerMode = PlayerMode;
 
   activeSleepTimer() {
     this.audioService.incrementSleepTimer(60 * 15);

--- a/gui/src/app/module/shared/shared.module.ts
+++ b/gui/src/app/module/shared/shared.module.ts
@@ -22,7 +22,7 @@ import {ClaimedRewardsComponent} from './component/claimed-rewards/claimed-rewar
 import {MarkdownComponent} from './component/markdown/markdown.component';
 import {AudioPlayerV2Component} from './component/audio-player-v2/audio-player-v2.component';
 import {AudioPlayerFixedComponent} from './component/audio-player-fixed/audio-player-fixed.component';
-import {NgbPopoverModule} from '@ng-bootstrap/ng-bootstrap';
+import {NgbDropdownModule, NgbPopoverModule} from '@ng-bootstrap/ng-bootstrap';
 import {FindReplaceComponent} from './component/find-replace/find-replace.component';
 import {MetadataEditorComponent} from './component/metadata-editor/metadata-editor.component';
 import {UserMenuComponent} from './component/user-menu/user-menu.component';
@@ -65,6 +65,7 @@ import {LoadingSpinnerComponent} from "./component/loading-spinner/loading-spinn
     CommonModule,
     RouterModule,
     ReactiveFormsModule,
+    NgbDropdownModule,
     NgbPopoverModule,
   ],
   providers: [],

--- a/gui/src/scss/theme.scss
+++ b/gui/src/scss/theme.scss
@@ -1,73 +1,79 @@
 @use "sass:color";
+@use "sass:map";
 
 $themes: (
   dark-theme: (
-    'text-color': #f7f7ff,
-    'bg-color': #17191F,
-    'fg-body': #2f343a,
-    'fg-body-darker': #2A2E33,
-    'progress-bg': #17191F,
-    'navbar-bg': #343A40,
-    'navbar-border': #343A40,
-    'code-bg': #17191F,
-    'hover-highlight': rgba(255, 255, 255, 0.2),
-
+    "text-color": #f7f7ff,
+    "bg-color": #17191f,
+    "fg-body": #2f343a,
+    "fg-body-darker": #2a2e33,
+    "progress-bg": #17191f,
+    "navbar-bg": #343a40,
+    "navbar-border": #343a40,
+    "code-bg": #17191f,
+    "hover-highlight": rgba(255, 255, 255, 0.2),
     // stop calling vars "lighter/darker" as it doesn't always apply for each theme.
-    'header-block-bg': #2A2E33,
-    'header-block-border': color.adjust(#2A2E33, $lightness: -5%),
-    'header-block-text': #f7f7ff,
-    'header-block-bg-highlight': color.adjust(#2A2E33, $lightness: 10%),
-
-    'body-block-border': #292d32,
-    'body-block-standout': color.adjust(#343A40, $lightness: 10%),
-
+    "header-block-bg": #2a2e33,
+    "header-block-border": color.adjust(#2a2e33, $lightness: -5%),
+    "header-block-text": #f7f7ff,
+    "header-block-bg-highlight": color.adjust(#2a2e33, $lightness: 10%),
+    "body-block-border": #292d32,
+    "body-block-standout": color.adjust(#343a40, $lightness: 10%),
     // used for inverting svg colours
-    'invert-pcnt': 90%,
+    "invert-pcnt": 90%,
   ),
   light-theme: (
-    'text-color': #333333,
-    'bg-color': #f6f6f6,
-    'fg-body': #fff,
-    'fg-body-darker': color.adjust(#F7F7F7, $lightness: -2%),
-    'progress-bg': #e9ecef,
-    'navbar-bg': #f6f6f6,
-    'navbar-border': #dee2e6,
-    'code-bg': #d9d9d9,
-    'hover-highlight':  color.adjust(#E15132, $alpha: -0.2),
-
+    "text-color": #333333,
+    "bg-color": #f6f6f6,
+    "fg-body": #fff,
+    "fg-body-darker": color.adjust(#f7f7f7, $lightness: -2%),
+    "progress-bg": #e9ecef,
+    "navbar-bg": #f6f6f6,
+    "navbar-border": #dee2e6,
+    "code-bg": #d9d9d9,
+    "hover-highlight": color.adjust(#e15132, $alpha: -0.2),
     // stop calling vars "lighter/darker" as it doesn't always apply for each theme.
-    'header-block-bg': color.adjust(#F7F7F7, $lightness: -2%),
-    'header-block-border': #dee2e6,
-    'header-block-text': #333333,
-    'header-block-bg-highlight': color.adjust(#F7F7F7, $lightness: -10%),
-
-    'body-block-border': #dee2e6,
-    'body-block-standout': color.adjust(#F7F7F7, $lightness: -10%),
-
+    "header-block-bg": color.adjust(#f7f7f7, $lightness: -2%),
+    "header-block-border": #dee2e6,
+    "header-block-text": #333333,
+    "header-block-bg-highlight": color.adjust(#f7f7f7, $lightness: -10%),
+    "body-block-border": #dee2e6,
+    "body-block-standout": color.adjust(#f7f7f7, $lightness: -10%),
     // used for inverting svg colours
-    'invert-pcnt': 0%,
-  )
+    "invert-pcnt": 0%,
+  ),
 );
 
 @mixin theme() {
   @each $theme, $map in $themes {
-
     $theme-map: $map !global;
 
     .#{$theme} & {
-      @content;    // the content inside @include theme() {...}
+      @content; // the content inside @include theme() {...}
     }
   }
   // no use of the variable $theme-map now
   $theme-map: null !global;
 }
 
+@mixin themeComponent() {
+  @each $theme, $map in $themes {
+    $theme-map: $map !global;
+
+    :host-context(.#{$theme}) & {
+      @content;
+    }
+  }
+
+  $theme-map: null !global;
+}
+
 @function theme-get($key) {
-  @return map-get($theme-map, $key);
+  @return map.get($theme-map, $key);
 }
 
 body.dark-theme {
-  background-color: #17191F;
+  background-color: #17191f;
   color: #fff;
 }
 


### PR DESCRIPTION
Based on https://github.com/warmans/rsk-search/issues/51

Realise my prettier format on save may have gone a big mad, let me know if you'd like me to revert some of the formatting changes that have happened because of that.

I've implemented:

* Close button becomes stop icon
* Vertical slider for volume
* NgbDropdown for mark as un/played and sleep timer
* Component theme mixin
* Lg+ should not be affected
* Small refactor of html to make controls buttons for keyboard navigation/interaction
  
**New layout on mobile**
<img width="844" height="168" alt="image" src="https://github.com/user-attachments/assets/9496e8c5-b687-416c-8d3a-7cd385cff286" />

**Vertical volume**
<img width="750" height="314" alt="image" src="https://github.com/user-attachments/assets/09a68539-a290-405e-a051-413efaafab31" />

**Un/played and sleep menu with dark theme**
<img width="826" height="238" alt="image" src="https://github.com/user-attachments/assets/2f9f70e0-5ca5-4159-895a-7e5d0d4bc23d" />

**Lg+ view of the player unaffected**
<img width="1957" height="102" alt="image" src="https://github.com/user-attachments/assets/ee518d67-5bcb-4a2e-bf1e-08410bee4768" />

