### PR TITLE
ensure fragments on episode page are included in history

### DIFF
--- a/gui/src/app/module/search/page/episode/episode.component.html
+++ b/gui/src/app/module/search/page/episode/episode.component.html
@@ -34,61 +34,62 @@
         <div class="card">
           <div class="card-header d-flex justify-content-between">
             <div>
-              {{ shortID }}@if (episode.name) {
-              <span class="text-muted"> - {{ episode.name }}</span>
-            }
+              {{ shortID }}
+              @if (episode.name) {
+                <span class="text-muted"> - {{ episode.name }}</span>
+              }
+            </div>
+            <div>
+              @if (previousEpisodeId) {
+                <a class="mr-2" [routerLink]="['/ep', previousEpisodeId]"><i class="bi bi-arrow-left"></i> Previous</a>
+              }
+              @if (nextEpisodeId) {
+                <a class="ml-2" [routerLink]="['/ep', nextEpisodeId]">Next <i class="bi bi-arrow-right"></i></a>
+              }
+            </div>
           </div>
-          <div>
-            @if (previousEpisodeId) {
-              <a class="mr-2" [routerLink]="['/ep', previousEpisodeId]"><i class="bi bi-arrow-left"></i> Previous</a>
-            }
-            @if (nextEpisodeId) {
-              <a class="ml-2" [routerLink]="['/ep', nextEpisodeId]">Next <i class="bi bi-arrow-right"></i></a>
-            }
-          </div>
-        </div>
-        <div class="card-body">
-          <div class="row">
-            <div class="col-lg-10">
-              <table class="table m-0">
-                <tr>
-                  <th class="border-top-0">Transcript Version</th>
-                  <td class="border-top-0 w-100">{{ episode.version }}</td>
-                </tr>
-                <tr>
-                  <th>Broadcast</th>
-                  <td>{{ episode.releaseDate | date }}</td>
-                </tr>
-                <tr>
-                  <th>Transcript Data</th>
-                  <td>
-                    <a target="_blank" href="/dl/episode/{{ episode.id }}.json">{{ episode.id }}.json</a>
-                    (or
-                    <a target="_blank" href="/dl/episode/{{ episode.id }}.txt">plaintext</a>)
-                  </td>
-                </tr>
-                <tr>
-                  <th>Presenters</th>
-                  <td>{{ episode.actors.join(", ") }}</td>
-                </tr>
-                @if (episode.summary) {
+          <div class="card-body">
+            <div class="row">
+              <div class="col-lg-10">
+                <table class="table m-0">
                   <tr>
-                    <th>Summary</th>
-                    <td>{{ episode.summary }}</td>
+                    <th class="border-top-0">Transcript Version</th>
+                    <td class="border-top-0 w-100">{{ episode.version }}</td>
                   </tr>
-                }
-                @if (episode.bestof || episode.locked) {
                   <tr>
-                    <th>Tags</th>
+                    <th>Broadcast</th>
+                    <td>{{ episode.releaseDate | date }}</td>
+                  </tr>
+                  <tr>
+                    <th>Transcript Data</th>
                     <td>
-                      @if (episode.bestof) {
-                        <span class="badge badge-secondary">Bestof</span>
-                      }
-                      @if (episode.locked) {
-                        <span
-                          class="badge badge-warning"
-                          title="Changes cannot be submitted for this transcript because it is in the process of being transcribed."
-                          >Locked</span
+                      <a target="_blank" href="/dl/episode/{{ episode.id }}.json">{{ episode.id }}.json</a>
+                      (or
+                      <a target="_blank" href="/dl/episode/{{ episode.id }}.txt">plaintext</a>)
+                    </td>
+                  </tr>
+                  <tr>
+                    <th>Presenters</th>
+                    <td>{{ episode.actors.join(", ") }}</td>
+                  </tr>
+                  @if (episode.summary) {
+                    <tr>
+                      <th>Summary</th>
+                      <td>{{ episode.summary }}</td>
+                    </tr>
+                  }
+                  @if (episode.bestof || episode.locked) {
+                    <tr>
+                      <th>Tags</th>
+                      <td>
+                        @if (episode.bestof) {
+                          <span class="badge badge-secondary">Bestof</span>
+                        }
+                        @if (episode.locked) {
+                          <span
+                            class="badge badge-warning"
+                            title="Changes cannot be submitted for this transcript because it is in the process of being transcribed."
+                            >Locked</span
                           >
                         }
                       </td>
@@ -245,7 +246,7 @@
                 <div>
                   @for (trivia of episode.trivia; track trivia; let last = $last) {
                     <div class="pb-1" [class.mb-3]="!last" [class.border-bottom]="!last">
-                      <app-markdown [raw]="trivia.description "></app-markdown>
+                      <app-markdown [raw]="trivia.description"></app-markdown>
                       <div><a [routerLink]="['/ep', episode?.id]" [fragment]="'pos-' + trivia.startPos">context</a></div>
                     </div>
                   }
@@ -298,64 +299,48 @@
                   }
                   @if (scrollToID || scrollToSeconds) {
                     <button class="btn btn-sm btn-info ml-2" (click)="clearSelection()"><i class="bi-escape"></i> Clear Selection</button>
-                    <!--a
-                    *ngIf="authenticated && episode.offsetAccuracyPcnt > 0"
-                    title="Audio export is provided on a best-effort basis. Since the audio timestamps are not 100% accurate, it's possible you won't get exactly the audio you expect."
-                    class="btn btn-sm btn-info ml-2"
-                    target="_blank"
-                    [href]="episode.audioUri+ '?ts='+selection.startTimestampMs+'-'+selection.endTimestampMs">
-                    <i class="bi-download"></i> Export selection audio
-                  </a-->
-                  @if (episode.offsetAccuracyPcnt > 0 && episode.media.audio) {
-                    <button
-                      title="Audio export is provided on a best-effort basis. Since the audio timestamps are not 100% accurate, it's possible you won't get exactly the audio you expect."
-                      class="btn btn-sm btn-info ml-2"
-                      (click)="toggleDownloadDialog()"
+                    @if (episode.offsetAccuracyPcnt > 0 && episode.media.audio) {
+                      <button
+                        title="Audio export is provided on a best-effort basis. Since the audio timestamps are not 100% accurate, it's possible you won't get exactly the audio you expect."
+                        class="btn btn-sm btn-info ml-2"
+                        (click)="toggleDownloadDialog()"
                       >
-                      <i class="bi-download"></i> Export Selected Audio
-                    </button>
+                        <i class="bi-download"></i> Export Selected Audio
+                      </button>
+                    }
                   }
-                  <!-- a
-                  *ngIf="authenticated && episode.media.video"
-                  class="btn btn-sm btn-info ml-2"
-                  target="_blank"
-                  [href]="'/dl/media/'+episode.id+'.gif'+'?ts='+selection.startTimestampMs+'-'+selection.endTimestampMs">
-                  <i class="bi-download"></i> Export GIF
-                </a-->
-              }
-            <!--button class="btn btn-sm btn-primary ml-2" *ngIf="scrollToID || scrollToSeconds" (click)="shareSelection()">Share Selection</button-->
-            @if (pendingChanges?.length === 0 && !episode.locked) {
-              <div class="ml-2">
-                <a class="btn btn-sm btn-info" [routerLink]="['/ep', id, 'change']"><i class="bi-pencil"></i> Submit Correction</a>
+                  @if (pendingChanges?.length === 0 && !episode.locked) {
+                    <div class="ml-2">
+                      <a class="btn btn-sm btn-info" [routerLink]="['/ep', id, 'change']"><i class="bi-pencil"></i> Submit Correction</a>
+                    </div>
+                  }
+                </div>
               </div>
+            </div>
+          </div>
+          <div class="card-body p-3">
+            <app-transcript
+              #transcript
+              [transcript]="episode"
+              [epid]="episode?.id"
+              [scrollToID]="scrollToID"
+              [scrollToSeconds]="scrollToSeconds"
+              [searchResultMode]="false"
+              [enableLineLinking]="true"
+              [enableLineCopy]="true"
+              [enableAudioLinks]="episode.media.audio && !episode.media.audioRestricted"
+              [media]="episode.media"
+              (emitAudioTimestamp)="onAudioTimestamp($event)"
+              (emitSelection)="selectSection($event)"
+            ></app-transcript>
+            @if (!episode?.transcript?.length) {
+              <div class="text-center p-4">No transcript available.</div>
             }
           </div>
         </div>
-      </div>
-    </div>
-    <div class="card-body p-3">
-      <app-transcript
-        #transcript
-        [transcript]="episode"
-        [epid]="episode?.id"
-        [scrollToID]="scrollToID"
-        [scrollToSeconds]="scrollToSeconds"
-        [searchResultMode]="false"
-        [enableLineLinking]="true"
-        [enableLineCopy]="true"
-        [enableAudioLinks]="episode.media.audio && !episode.media.audioRestricted"
-        [media]="episode.media"
-        (emitAudioTimestamp)="onAudioTimestamp($event)"
-        (emitSelection)="selectSection($event)"
-      ></app-transcript>
-      @if (!episode?.transcript?.length) {
-        <div class="text-center p-4">No transcript available.</div>
       }
     </div>
   </div>
-}
-</div>
-</div>
 </div>
 @if (error && !episode) {
   <div class="container-fluid w-25">
@@ -395,7 +380,7 @@
             [startTimestampMs]="selection.startTimestampMs"
             [endTimestampMs]="selection.endTimestampMs"
             [episodeDurationMs]="episodeDurationMs"
-            >
+          >
           </app-audio-waveform>
         </div>
       </div>

--- a/gui/src/app/module/search/page/episode/episode.component.ts
+++ b/gui/src/app/module/search/page/episode/episode.component.ts
@@ -1,32 +1,30 @@
 import {Component, EventEmitter, OnDestroy, OnInit, ViewChild} from '@angular/core';
-import {ActivatedRoute, Data, Router} from '@angular/router';
+import {ActivatedRoute, Data, NavigationEnd, Router} from '@angular/router';
 import {SearchAPIClient} from 'src/app/lib/api-client/services/search';
-import {DialogType, RskArchive, RskDialog, RskTranscript, RskTranscriptChange, RskTranscriptChangeList, RskTrivia} from 'src/app/lib/api-client/models';
-import {ViewportScroller} from '@angular/common';
-import {takeUntil} from 'rxjs/operators';
+import {DialogType, RskArchive, RskDialog, RskTranscript, RskTranscriptChange, RskTranscriptChangeList} from 'src/app/lib/api-client/models';
+import {Location, ViewportScroller} from '@angular/common';
+import {filter, takeUntil} from 'rxjs/operators';
 import {Title} from '@angular/platform-browser';
 import {SessionService} from '../../../core/service/session/session.service';
 import {And, Eq, Neq} from 'src/app/lib/filter-dsl/filter';
 import {Bool, Str} from 'src/app/lib/filter-dsl/value';
 import {MetaService} from '../../../core/service/meta/meta.service';
-import {AudioService, PlayerMode, PlayerState, Status} from '../../../core/service/audio/audio.service';
+import {AudioService, PlayerState, Status} from '../../../core/service/audio/audio.service';
 import {Section, TranscriptComponent} from '../../../shared/component/transcript/transcript.component';
 import {combineLatest} from 'rxjs';
-import {parseSection} from "../../../shared/lib/fragment";
-import {ClipboardService} from "../../../core/service/clipboard/clipboard.service";
+import {parseSection} from '../../../shared/lib/fragment';
+import {ClipboardService} from '../../../core/service/clipboard/clipboard.service';
 import {CommunityAPIClient} from 'src/app/lib/api-client/services/community';
 import {episodeIdVariations} from 'src/app/lib/util';
-import {AlertService} from "../../../core/service/alert/alert.service";
-import {Tscript} from "../../../shared/lib/tscript";
+import {AlertService} from '../../../core/service/alert/alert.service';
 
 @Component({
-    selector: 'app-episode',
-    templateUrl: './episode.component.html',
-    styleUrls: ['./episode.component.scss'],
-    standalone: false
+  selector: 'app-episode',
+  templateUrl: './episode.component.html',
+  styleUrls: ['./episode.component.scss'],
+  standalone: false
 })
 export class EpisodeComponent implements OnInit, OnDestroy {
-
   loading: boolean = false;
 
   id: string;
@@ -90,109 +88,114 @@ export class EpisodeComponent implements OnInit, OnDestroy {
     private audioService: AudioService,
     private clipboard: ClipboardService,
     private alertService: AlertService,
+    private location: Location
   ) {
     route.paramMap.pipe(takeUntil(this.unsubscribe$)).subscribe((d: Data) => {
       this.loadEpisode(d.params['id']);
-    });
-    route.fragment.pipe(takeUntil(this.unsubscribe$)).subscribe((f) => {
-      if (!f) {
-        this.scrollToID = undefined;
-        this.scrollToSeconds = undefined;
-        return;
-      }
-      if (f.startsWith('pos-')) {
-        this.scrollToID = f;
-        this.selection = parseSection(f, (this.episode?.transcript || []));
-      }
-      if (f.startsWith('sec-')) {
-        this.scrollToSeconds = parseInt(f.replace('sec-', ''));
-      }
     });
     sessionService.onTokenChange.pipe(takeUntil(this.unsubscribe$)).subscribe((token: string): void => {
       if (token != null) {
         this.authenticated = true;
         const claims = sessionService.getClaims();
-        this.authorIdentifier = `${claims.oauth_provider}:${claims.identity.name}`
+        this.authorIdentifier = `${claims.oauth_provider}:${claims.identity.name}`;
       }
     });
   }
 
   ngOnInit(): void {
+    const fragment = this.router.url.split('#')[1] ?? null;
+    this.handleFragment(fragment);
+
+    this.router.events
+      .pipe(
+        filter((event) => event instanceof NavigationEnd),
+        takeUntil(this.unsubscribe$),
+      )
+      .subscribe((event) => {
+        const fragment = event.url.split('#')[1] ?? null;
+        this.handleFragment(fragment);
+      });
+
     this.audioService.status.pipe(takeUntil(this.unsubscribe$)).subscribe((sta: Status) => {
       this.audioStatus = sta;
     });
   }
 
   loadEpisode(id: string) {
-
     this.id = id;
     this.loading = true;
     this.error = undefined;
 
     combineLatest([
-      this.apiClient.getTranscript({epid: this.id}),
+      this.apiClient.getTranscript({ epid: this.id }),
       this.meta.getMeta(),
-      this.communityApiClient.listArchive({episodeIds: episodeIdVariations(this.id)}),
-    ]).pipe(takeUntil(this.unsubscribe$)).subscribe(
-      ([ep, metadata, media]) => {
+      this.communityApiClient.listArchive({ episodeIds: episodeIdVariations(this.id) }),
+    ])
+      .pipe(takeUntil(this.unsubscribe$))
+      .subscribe(
+        ([ep, metadata, media]) => {
+          this.episode = ep;
+          this.shortID = ep.shortId;
+          this.titleService.setTitle(ep.id);
+          this.transcribers = ep.contributors.join(', ');
+          this.episodeImage = ep.metadata['cover_art_url'] ? ep.metadata['cover_art_url'] : `/assets/cover/${ep.publication}-s${ep.series}-lg.jpeg`;
+          this.episodeDurationMs = parseInt(ep.metadata['duration_ms']);
+          this.media = media.items ?? [];
 
-        this.episode = ep;
-        this.shortID = ep.shortId;
-        this.titleService.setTitle(ep.id);
-        this.transcribers = ep.contributors.join(', ');
-        this.episodeImage = ep.metadata['cover_art_url'] ? ep.metadata['cover_art_url'] : `/assets/cover/${ep.publication}-s${ep.series}-lg.jpeg`;
-        this.episodeDurationMs = parseInt(ep.metadata['duration_ms']);
-        this.media = media.items ?? [];
+          this.quotes = [];
+          this.songs = [];
+          ep.transcript.forEach((r: RskDialog) => {
+            if (r.notable) {
+              this.quotes.push(r);
+            }
+            if (r.type === DialogType.SONG) {
+              this.songs.push(r);
+            }
+          });
 
-        this.quotes = [];
-        this.songs = [];
-        ep.transcript.forEach((r: RskDialog) => {
-          if (r.notable) {
-            this.quotes.push(r);
+          const curIndex = (metadata.episodeShortIds || []).findIndex((v) => v == ep.shortId);
+          if (curIndex === -1) {
+            console.error(`failed to find episode in metadata ${ep.shortId}`);
           }
-          if (r.type === DialogType.SONG) {
-            this.songs.push(r);
+
+          this.previousEpisodeId = this.nextEpisodeId = null;
+          if (curIndex > 0 && (metadata.episodeShortIds || []).length > 0) {
+            this.previousEpisodeId = `ep-${metadata.episodeShortIds[curIndex - 1]}`;
           }
-        });
+          if (curIndex < (metadata.episodeShortIds || []).length - 1) {
+            this.nextEpisodeId = `ep-${metadata.episodeShortIds[curIndex + 1]}`;
+          }
 
-        const curIndex = (metadata.episodeShortIds || []).findIndex((v) => v == ep.shortId);
-        if (curIndex === -1) {
-          console.error(`failed to find episode in metadata ${ep.shortId}`);
-        }
+          const availableInfoPanels = [];
+          if (this.episode?.synopses && this.episode?.synopses.length > 0) {
+            availableInfoPanels.push('synopsis');
+          }
+          if (this.quotes && this.episode?.synopses.length > 0) {
+            availableInfoPanels.push('quotes');
+          }
+          if (this.songs && this.songs.length > 0) {
+            availableInfoPanels.push('songs');
+          }
+          if ((this.episode.trivia || []).length > 0) {
+            availableInfoPanels.push('trivia');
+          }
+          this.activeInfoPanel = availableInfoPanels.length > 0 ? availableInfoPanels[0] : undefined;
+          this.selection = parseSection(this.scrollToID, this.episode?.transcript || []);
+        },
+        (err) => {
+          this.error = 'Failed to fetch episode';
+        },
+      )
+      .add(() => (this.loading = false));
 
-        this.previousEpisodeId = this.nextEpisodeId = null;
-        if (curIndex > 0 && (metadata.episodeShortIds || []).length > 0) {
-          this.previousEpisodeId = `ep-${metadata.episodeShortIds[curIndex - 1]}`;
-        }
-        if (curIndex < ((metadata.episodeShortIds || []).length - 1)) {
-          this.nextEpisodeId = `ep-${metadata.episodeShortIds[curIndex + 1]}`;
-        }
-
-        const availableInfoPanels = [];
-        if (this.episode?.synopses && this.episode?.synopses.length > 0) {
-          availableInfoPanels.push("synopsis");
-        }
-        if (this.quotes && this.episode?.synopses.length > 0) {
-          availableInfoPanels.push("quotes");
-        }
-        if (this.songs && this.songs.length > 0) {
-          availableInfoPanels.push("songs");
-        }
-        if ((this.episode.trivia || []).length > 0) {
-          availableInfoPanels.push("trivia");
-        }
-        this.activeInfoPanel = (availableInfoPanels.length > 0) ? availableInfoPanels[0] : undefined;
-        this.selection = parseSection(this.scrollToID, (this.episode?.transcript || []));
-      },
-      (err) => {
-        this.error = 'Failed to fetch episode';
-      }).add(() => this.loading = false);
-
-    this.apiClient.listTranscriptChanges({
-      filter: And(Eq('epid', Str(this.id)), Eq('merged', Bool(false)), Neq('state', Str('pending')), Neq('state', Str('rejected'))).print()
-    }).pipe(takeUntil(this.unsubscribe$)).subscribe((ep: RskTranscriptChangeList) => {
-      this.pendingChanges = ep.changes;
-    });
+    this.apiClient
+      .listTranscriptChanges({
+        filter: And(Eq('epid', Str(this.id)), Eq('merged', Bool(false)), Neq('state', Str('pending')), Neq('state', Str('rejected'))).print(),
+      })
+      .pipe(takeUntil(this.unsubscribe$))
+      .subscribe((ep: RskTranscriptChangeList) => {
+        this.pendingChanges = ep.changes;
+      });
   }
 
   query(field: string, value: string): string {
@@ -224,18 +227,22 @@ export class EpisodeComponent implements OnInit, OnDestroy {
   }
 
   selectSection(sel: Section) {
-    this.router.navigate([], {fragment: `pos-${sel.startPos}-${sel.endPos}`});
+    this.router.navigate([], { fragment: `pos-${sel.startPos}-${sel.endPos}` });
   }
 
   clearSelection() {
-    this.router.navigate([], {});
+    const includesFragment = this.location.path(true).includes('#');
+    if (includesFragment) {
+      this.location.go(this.location.path(false));
+      this.handleFragment(null);
+    }
   }
 
   copySelection() {
     this.clipboard.copyTextToClipboard(
       (this.episode.transcript.slice(this.selection.startPos - 1, this.selection.endPos) || [])
-        .map((d: RskDialog): string => d.actor ? `**${d.actor}:** ${d.content}` : `*${d.content}*`)
-        .join("\n")
+        .map((d: RskDialog): string => (d.actor ? `**${d.actor}:** ${d.content}` : `*${d.content}*`))
+        .join('\n'),
     );
   }
 
@@ -256,11 +263,24 @@ export class EpisodeComponent implements OnInit, OnDestroy {
     if (!userScore || !this.authenticated) {
       return;
     }
-    this.apiClient.setTranscriptRatingScore(
-      {epid: this.episode.shortId, body: {score: userScore.rating}}
-    ).subscribe(() => {
-      this.alertService.success("Rating submitted")
+    this.apiClient.setTranscriptRatingScore({ epid: this.episode.shortId, body: { score: userScore.rating } }).subscribe(() => {
+      this.alertService.success('Rating submitted');
       this.episode.ratings.scores[this.authorIdentifier] = userScore.rating;
     });
+  }
+
+  private handleFragment(fragment: string | null): void {
+    if (!fragment) {
+      this.scrollToID = null;
+      this.scrollToSeconds = null;
+      return;
+    }
+    if (fragment.startsWith('pos-')) {
+      this.scrollToID = fragment;
+      this.selection = parseSection(fragment, this.episode?.transcript || []);
+    }
+    if (fragment.startsWith('sec-')) {
+      this.scrollToSeconds = parseInt(fragment.replace('sec-', ''));
+    }
   }
 }


### PR DESCRIPTION
`.navigate([], {})` was just refusing to ensure the route with fragment was preserved in history. by using `Location` we bypass the router to make sure the clear selection url is on the history. we can now clear and select as many pos-n fragments as we want and go back to them all.

Should hopefully resolve: https://github.com/warmans/rsk-search/issues/61